### PR TITLE
Implement complex types

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,3 +22,7 @@ jobs:
           python -m pip install tox tox-uv
       - name: Test with tox
         run: tox
+      - name: Test with doctest
+        run: |
+          python -m pip install -e .
+          python -m doctest src/python/bag3d/specs/core.py -v

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ tests/python/__pycache__
 
 # Build
 src/python/bag3d_specs.egg-info
+
+# tmp
+/tmp

--- a/tests/python/test_specs.py
+++ b/tests/python/test_specs.py
@@ -1,5 +1,5 @@
 from bag3d.specs.resources import get_resource_file_path
-from bag3d.specs.core import Attribute, AttributeType, load_attributes_spec
+from bag3d.specs.core import Attribute, AttributeType, load_attributes_spec, BaseType
 
 
 def test_get_resource_file_path():
@@ -55,7 +55,8 @@ def test_attribute_array():
 
     attr = Attribute.from_dict("test_bool", data)
 
-    assert attr.items.type == AttributeType.INT
+    assert attr.type == AttributeType(BaseType.ARRAY, BaseType.INT)
+    assert str(attr.type) == "ARRAY<INT>"
     assert attr.items.scale.en == "ratio"
 
 


### PR DESCRIPTION
Implements complex types, that are a combination of a _base_-type and a _sub_-type.
We need complex types for representing the type system of OGR (see https://raw.githubusercontent.com/OSGeo/gdal/refs/heads/master/ogr/data/ogr_fields_override.schema.json).

Only keeps the _python_ and _ogr_ type name conversions, because we don't need the rest for now and I didn't want to spend time on them.

The main difference is that the `AttributeType` is constructed from one or two `BaseType`-s, or a dict with the `type` and `items` properties (see schema).