### PR TITLE
Format locations

### DIFF
--- a/resources/attributes.json
+++ b/resources/attributes.json
@@ -6,7 +6,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": null,
+    "valueFormat": null,
     "semanticType": "identifier",
     "values": null,
     "description": {
@@ -25,7 +25,7 @@
     "appliesTo": "RoofSurface",
     "precision": null,
     "unit": null,
-    "format": null,
+    "valueFormat": null,
     "semanticType": "identifier",
     "values": null,
     "description": {
@@ -44,7 +44,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": null,
+    "valueFormat": null,
     "semanticType": "identifier",
     "values": null,
     "description": {
@@ -63,7 +63,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": "YYYY",
+    "valueFormat": "YYYY",
     "semanticType": "year",
     "values": null,
     "description": {
@@ -82,7 +82,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": null,
+    "valueFormat": null,
     "semanticType": "category",
     "values": null,
     "description": {
@@ -101,7 +101,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": null,
+    "valueFormat": null,
     "semanticType": "flag",
     "values": null,
     "description": {
@@ -120,7 +120,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": "YYYY-MM-DD",
+    "valueFormat": "YYYY-MM-DD",
     "semanticType": "day",
     "values": null,
     "description": {
@@ -139,7 +139,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": null,
+    "valueFormat": null,
     "semanticType": "identifier",
     "values": null,
     "description": {
@@ -158,7 +158,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": null,
+    "valueFormat": null,
     "semanticType": "identifier",
     "values": null,
     "description": {
@@ -177,7 +177,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": "YYYY-MM-DD",
+    "valueFormat": "YYYY-MM-DD",
     "semanticType": "day",
     "values": null,
     "description": {
@@ -196,7 +196,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": "YYYY-MM-DD",
+    "valueFormat": "YYYY-MM-DD",
     "semanticType": "day",
     "values": null,
     "description": {
@@ -215,7 +215,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": "YYYY-MM-DDThh:mm:ss.sss",
+    "valueFormat": "YYYY-MM-DDThh:mm:ss.sss",
     "semanticType": "millisecond",
     "values": null,
     "description": {
@@ -234,7 +234,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": "YYYY-MM-DDThh:mm:ss.sss",
+    "valueFormat": "YYYY-MM-DDThh:mm:ss.sss",
     "semanticType": "millisecond",
     "values": null,
     "description": {
@@ -253,7 +253,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": "YYYY-MM-DDThh:mm:ss.sss",
+    "valueFormat": "YYYY-MM-DDThh:mm:ss.sss",
     "semanticType": "millisecond",
     "values": null,
     "description": {
@@ -272,7 +272,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": "YYYY-MM-DDThh:mm:ss.sss",
+    "valueFormat": "YYYY-MM-DDThh:mm:ss.sss",
     "semanticType": "millisecond",
     "values": null,
     "description": {
@@ -291,7 +291,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": "YYYY-MM-DDThh:mm:ss.sss",
+    "valueFormat": "YYYY-MM-DDThh:mm:ss.sss",
     "semanticType": "millisecond",
     "values": null,
     "description": {
@@ -310,7 +310,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": "YYYY-MM-DDThh:mm:ss.sss",
+    "valueFormat": "YYYY-MM-DDThh:mm:ss.sss",
     "semanticType": "millisecond",
     "values": null,
     "description": {
@@ -329,7 +329,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": "YYYY-MM-DDThh:mm:ss.sss",
+    "valueFormat": "YYYY-MM-DDThh:mm:ss.sss",
     "semanticType": "millisecond",
     "values": null,
     "description": {
@@ -351,7 +351,7 @@
       "en": "metre",
       "nl": "meter"
     },
-    "format": null,
+    "valueFormat": null,
     "semanticType": "elevation",
     "values": null,
     "description": {
@@ -370,7 +370,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": null,
+    "valueFormat": null,
     "semanticType": "category",
     "values": {
       "slanted": {
@@ -410,7 +410,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": "YYYY",
+    "valueFormat": "YYYY",
     "semanticType": "year",
     "values": null,
     "description": {
@@ -429,7 +429,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": null,
+    "valueFormat": null,
     "semanticType": "text",
     "values": null,
     "description": {
@@ -448,7 +448,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": null,
+    "valueFormat": null,
     "semanticType": "flag",
     "values": null,
     "description": {
@@ -467,7 +467,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": null,
+    "valueFormat": null,
     "semanticType": "flag",
     "values": null,
     "description": {
@@ -489,7 +489,7 @@
       "en": "metre",
       "nl": "meter"
     },
-    "format": null,
+    "valueFormat": null,
     "semanticType": "elevation",
     "values": null,
     "description": {
@@ -511,7 +511,7 @@
       "en": "metre",
       "nl": "meter"
     },
-    "format": null,
+    "valueFormat": null,
     "semanticType": "elevation",
     "values": null,
     "description": {
@@ -533,7 +533,7 @@
       "en": "metre",
       "nl": "meter"
     },
-    "format": null,
+    "valueFormat": null,
     "semanticType": "elevation",
     "values": null,
     "description": {
@@ -555,7 +555,7 @@
       "en": "metre",
       "nl": "meter"
     },
-    "format": null,
+    "valueFormat": null,
     "semanticType": "elevation",
     "values": null,
     "description": {
@@ -575,7 +575,7 @@
     "semanticType": "list",
     "precision": null,
     "unit": null,
-    "format": null,
+    "valueFormat": null,
     "values": null,
     "scale": null,
     "description": {
@@ -603,7 +603,7 @@
     "semanticType": "list",
     "precision": null,
     "unit": null,
-    "format": null,
+    "valueFormat": null,
     "values": null,
     "scale": null,
     "description": {
@@ -631,7 +631,7 @@
     "semanticType": "list",
     "precision": null,
     "unit": null,
-    "format": null,
+    "valueFormat": null,
     "values": null,
     "scale": null,
     "description": {
@@ -661,7 +661,7 @@
       "en": "metre",
       "nl": "meter"
     },
-    "format": null,
+    "valueFormat": null,
     "semanticType": "error",
     "values": null,
     "description": {
@@ -683,7 +683,7 @@
       "en": "metre",
       "nl": "meter"
     },
-    "format": null,
+    "valueFormat": null,
     "semanticType": "error",
     "values": null,
     "description": {
@@ -705,7 +705,7 @@
       "en": "metre",
       "nl": "meter"
     },
-    "format": null,
+    "valueFormat": null,
     "semanticType": "error",
     "values": null,
     "description": {
@@ -724,7 +724,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": null,
+    "valueFormat": null,
     "semanticType": "flag",
     "values": {
       "true": {
@@ -752,7 +752,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": null,
+    "valueFormat": null,
     "semanticType": "fraction",
     "values": null,
     "description": {
@@ -771,7 +771,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": null,
+    "valueFormat": null,
     "semanticType": "fraction",
     "values": null,
     "description": {
@@ -793,7 +793,7 @@
       "en": "metre",
       "nl": "meter"
     },
-    "format": null,
+    "valueFormat": null,
     "semanticType": "length",
     "values": null,
     "description": {
@@ -815,7 +815,7 @@
       "en": "metre",
       "nl": "meter"
     },
-    "format": null,
+    "valueFormat": null,
     "semanticType": "length",
     "values": null,
     "description": {
@@ -834,7 +834,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": null,
+    "valueFormat": null,
     "semanticType": "category",
     "values": {
       "PREFERRED_AND_LATEST": {
@@ -877,7 +877,7 @@
       "en": "points per square metre",
       "nl": "punten per vierkante meter"
     },
-    "format": null,
+    "valueFormat": null,
     "semanticType": "density",
     "values": null,
     "description": {
@@ -899,7 +899,7 @@
       "en": "points per square metre",
       "nl": "punten per vierkante meter"
     },
-    "format": null,
+    "valueFormat": null,
     "semanticType": "density",
     "values": null,
     "description": {
@@ -921,7 +921,7 @@
       "en": "cubic metre",
       "nl": "kubieke meter"
     },
-    "format": null,
+    "valueFormat": null,
     "semanticType": "volume",
     "values": null,
     "description": {
@@ -943,7 +943,7 @@
       "en": "cubic metre",
       "nl": "kubieke meter"
     },
-    "format": null,
+    "valueFormat": null,
     "semanticType": "volume",
     "values": null,
     "description": {
@@ -965,7 +965,7 @@
       "en": "cubic metre",
       "nl": "kubieke meter"
     },
-    "format": null,
+    "valueFormat": null,
     "semanticType": "volume",
     "values": null,
     "description": {
@@ -987,7 +987,7 @@
       "en": "square metre",
       "nl": "vierkante meter"
     },
-    "format": null,
+    "valueFormat": null,
     "semanticType": "area",
     "values": null,
     "description": {
@@ -1009,7 +1009,7 @@
       "en": "square metre",
       "nl": "vierkante meter"
     },
-    "format": null,
+    "valueFormat": null,
     "semanticType": "area",
     "values": null,
     "description": {
@@ -1031,7 +1031,7 @@
       "en": "square metre",
       "nl": "vierkante meter"
     },
-    "format": null,
+    "valueFormat": null,
     "semanticType": "area",
     "values": null,
     "description": {
@@ -1053,7 +1053,7 @@
       "en": "square metre",
       "nl": "vierkante meter"
     },
-    "format": null,
+    "valueFormat": null,
     "semanticType": "area",
     "values": null,
     "description": {
@@ -1075,7 +1075,7 @@
       "en": "square metre",
       "nl": "vierkante meter"
     },
-    "format": null,
+    "valueFormat": null,
     "semanticType": "area",
     "values": null,
     "description": {
@@ -1097,7 +1097,7 @@
       "en": "square metre",
       "nl": "vierkante meter"
     },
-    "format": null,
+    "valueFormat": null,
     "semanticType": "area",
     "values": null,
     "description": {
@@ -1117,7 +1117,7 @@
     "semanticType": "list",
     "precision": null,
     "unit": null,
-    "format": null,
+    "valueFormat": null,
     "values": null,
     "scale": null,
     "description": {
@@ -1144,7 +1144,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": null,
+    "valueFormat": null,
     "semanticType": "count",
     "values": null,
     "description": {
@@ -1163,7 +1163,7 @@
     "appliesTo": "Building",
     "precision": null,
     "unit": null,
-    "format": null,
+    "valueFormat": null,
     "semanticType": "flag",
     "values": {
       "true": {
@@ -1194,7 +1194,7 @@
       "en": "degrees",
       "nl": "graden"
     },
-    "format": null,
+    "valueFormat": null,
     "semanticType": "angle",
     "values": null,
     "description": {
@@ -1216,7 +1216,7 @@
       "en": "degrees",
       "nl": "graden"
     },
-    "format": null,
+    "valueFormat": null,
     "semanticType": "angle",
     "values": null,
     "description": {

--- a/resources/attributes.json
+++ b/resources/attributes.json
@@ -3,7 +3,18 @@
     "type": "int",
     "source": "roofer",
     "nullable": false,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "gpkg": {
+        "locations": [
+          "lod13_3d",
+          "lod12_2d",
+          "lod22_2d",
+          "lod22_3d",
+          "lod13_2d",
+          "lod12_3d"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": null,
@@ -22,7 +33,15 @@
     "type": "int",
     "source": "roofer",
     "nullable": false,
-    "appliesTo": "RoofSurface",
+    "appliesTo": {
+      "gpkg": {
+        "locations": [
+          "lod22_2d",
+          "lod12_2d",
+          "lod13_2d"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": null,
@@ -41,7 +60,24 @@
     "type": "string",
     "source": "BAG,roofer",
     "nullable": false,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "lod13_3d",
+          "lod12_2d",
+          "pand",
+          "lod22_2d",
+          "lod22_3d",
+          "lod13_2d",
+          "lod12_3d"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": null,
@@ -60,7 +96,18 @@
     "type": "int",
     "source": "BAG",
     "nullable": true,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": "YYYY",
@@ -79,7 +126,18 @@
     "type": "string",
     "source": "BAG",
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": null,
@@ -98,7 +156,18 @@
     "type": "string",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": null,
@@ -117,7 +186,18 @@
     "type": "date",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": "YYYY-MM-DD",
@@ -136,7 +216,18 @@
     "type": "string",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": null,
@@ -155,7 +246,18 @@
     "type": "int",
     "source": "BAG",
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": null,
@@ -174,7 +276,18 @@
     "type": "date",
     "source": "BAG",
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": "YYYY-MM-DD",
@@ -193,7 +306,18 @@
     "type": "date",
     "source": "BAG",
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": "YYYY-MM-DD",
@@ -212,7 +336,18 @@
     "type": "datetime",
     "source": "BAG",
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": "YYYY-MM-DDThh:mm:ss.sss",
@@ -231,7 +366,18 @@
     "type": "datetime",
     "source": "BAG",
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": "YYYY-MM-DDThh:mm:ss.sss",
@@ -250,7 +396,18 @@
     "type": "datetime",
     "source": "BAG",
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": "YYYY-MM-DDThh:mm:ss.sss",
@@ -269,7 +426,18 @@
     "type": "datetime",
     "source": "BAG",
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": "YYYY-MM-DDThh:mm:ss.sss",
@@ -288,7 +456,18 @@
     "type": "datetime",
     "source": "BAG",
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": "YYYY-MM-DDThh:mm:ss.sss",
@@ -307,7 +486,18 @@
     "type": "datetime",
     "source": "BAG",
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": "YYYY-MM-DDThh:mm:ss.sss",
@@ -326,7 +516,18 @@
     "type": "datetime",
     "source": "BAG",
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": "YYYY-MM-DDThh:mm:ss.sss",
@@ -345,7 +546,18 @@
     "type": "float",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": {
       "en": "metre",
@@ -367,14 +579,25 @@
     "type": "string",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": null,
     "semanticType": "category",
     "values": {
       "slanted": {
-        "nl": "Dat met ten minste één schuin oppervlak.",
+        "nl": "Dat met ten minste \u00e9\u00e9n schuin oppervlak.",
         "en": "Roof with at least one slanted surface."
       },
       "multiple horizontal": {
@@ -407,7 +630,18 @@
     "type": "int",
     "source": null,
     "nullable": false,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": "YYYY",
@@ -426,7 +660,18 @@
     "type": "string",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": null,
@@ -445,7 +690,18 @@
     "type": "bool",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": null,
@@ -464,7 +720,7 @@
     "type": "bool",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {},
     "precision": null,
     "unit": null,
     "valueFormat": null,
@@ -483,7 +739,14 @@
     "type": "float",
     "source": null,
     "nullable": null,
-    "appliesTo": "RoofSurface",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "RoofSurface",
+          "Building"
+        ]
+      }
+    },
     "precision": null,
     "unit": {
       "en": "metre",
@@ -505,7 +768,14 @@
     "type": "float",
     "source": null,
     "nullable": null,
-    "appliesTo": "RoofSurface",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "RoofSurface",
+          "Building"
+        ]
+      }
+    },
     "precision": null,
     "unit": {
       "en": "metre",
@@ -527,7 +797,14 @@
     "type": "float",
     "source": null,
     "nullable": null,
-    "appliesTo": "RoofSurface",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "RoofSurface",
+          "Building"
+        ]
+      }
+    },
     "precision": null,
     "unit": {
       "en": "metre",
@@ -549,7 +826,14 @@
     "type": "float",
     "source": null,
     "nullable": null,
-    "appliesTo": "RoofSurface",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "RoofSurface",
+          "Building"
+        ]
+      }
+    },
     "precision": null,
     "unit": {
       "en": "metre",
@@ -571,7 +855,18 @@
     "type": "array",
     "source": null,
     "nullable": false,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "semanticType": "list",
     "precision": null,
     "unit": null,
@@ -599,7 +894,18 @@
     "type": "array",
     "source": null,
     "nullable": false,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "semanticType": "list",
     "precision": null,
     "unit": null,
@@ -627,7 +933,18 @@
     "type": "array",
     "source": null,
     "nullable": false,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "semanticType": "list",
     "precision": null,
     "unit": null,
@@ -655,7 +972,18 @@
     "type": "float",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": {
       "en": "metre",
@@ -677,7 +1005,18 @@
     "type": "float",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": {
       "en": "metre",
@@ -699,7 +1038,18 @@
     "type": "float",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": {
       "en": "metre",
@@ -721,7 +1071,18 @@
     "type": "bool",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": null,
@@ -749,7 +1110,18 @@
     "type": "float",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": null,
@@ -768,7 +1140,18 @@
     "type": "float",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": null,
@@ -787,7 +1170,18 @@
     "type": "float",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": {
       "en": "metre",
@@ -809,7 +1203,18 @@
     "type": "float",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": {
       "en": "metre",
@@ -831,7 +1236,18 @@
     "type": "string",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": null,
@@ -871,7 +1287,18 @@
     "type": "int",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": {
       "en": "points per square metre",
@@ -893,7 +1320,18 @@
     "type": "int",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": {
       "en": "points per square metre",
@@ -915,7 +1353,18 @@
     "type": "float",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": {
       "en": "cubic metre",
@@ -937,7 +1386,18 @@
     "type": "float",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": {
       "en": "cubic metre",
@@ -959,7 +1419,18 @@
     "type": "float",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": {
       "en": "cubic metre",
@@ -981,7 +1452,18 @@
     "type": "float",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": {
       "en": "square metre",
@@ -1003,7 +1485,18 @@
     "type": "float",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": {
       "en": "square metre",
@@ -1025,7 +1518,18 @@
     "type": "float",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": {
       "en": "square metre",
@@ -1047,7 +1551,18 @@
     "type": "float",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": {
       "en": "square metre",
@@ -1069,7 +1584,18 @@
     "type": "float",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": {
       "en": "square metre",
@@ -1091,7 +1617,18 @@
     "type": "float",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": {
       "en": "square metre",
@@ -1113,7 +1650,15 @@
     "type": "array",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "gpkg": {
+        "locations": [
+          "lod22_3d",
+          "lod13_3d",
+          "lod12_3d"
+        ]
+      }
+    },
     "semanticType": "list",
     "precision": null,
     "unit": null,
@@ -1141,7 +1686,18 @@
     "type": "int",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "Building"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": null,
@@ -1160,7 +1716,13 @@
     "type": "string",
     "source": null,
     "nullable": null,
-    "appliesTo": "Building",
+    "appliesTo": {
+      "gpkg": {
+        "locations": [
+          "pand"
+        ]
+      }
+    },
     "precision": null,
     "unit": null,
     "valueFormat": null,
@@ -1188,7 +1750,18 @@
     "type": "float",
     "source": null,
     "nullable": null,
-    "appliesTo": "RoofSurface",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "RoofSurface"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "lod22_2d"
+        ]
+      }
+    },
     "precision": null,
     "unit": {
       "en": "degrees",
@@ -1210,7 +1783,18 @@
     "type": "float",
     "source": null,
     "nullable": null,
-    "appliesTo": "RoofSurface",
+    "appliesTo": {
+      "cityjson": {
+        "locations": [
+          "RoofSurface"
+        ]
+      },
+      "gpkg": {
+        "locations": [
+          "lod22_2d"
+        ]
+      }
+    },
     "precision": null,
     "unit": {
       "en": "degrees",

--- a/resources/attributes.schema.json
+++ b/resources/attributes.schema.json
@@ -16,7 +16,7 @@
         "appliesTo",
         "precision",
         "unit",
-        "format",
+        "valueFormat",
         "semanticType",
         "values",
         "description",
@@ -59,7 +59,7 @@
               "$ref": "#/definitions/format-gpkg"
             }
           },
-          "minProperties": 1,
+          "minProperties": 0,
           "additionalProperties": false
         },
         "precision": {
@@ -169,39 +169,45 @@
     "format-cityjson": {
       "type": "object",
       "properties": {
-        "location": {
-          "type": "string",
-          "enum": [
-            "Building",
-            "BuildingPart",
-            "RoofSurface",
-            "WallSurface",
-            "GroundSurface",
-            "ClosureSurface",
-            "OuterCeilingSurface",
-            "OuterFloorSurface",
-            "InteriorWallSurface",
-            "CeilingSurface",
-            "FloorSurface"
-          ],
-          "description": "The CitObject or Semantic type where the attribute is located."
+        "locations": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Building",
+              "BuildingPart",
+              "RoofSurface",
+              "WallSurface",
+              "GroundSurface",
+              "ClosureSurface",
+              "OuterCeilingSurface",
+              "OuterFloorSurface",
+              "InteriorWallSurface",
+              "CeilingSurface",
+              "FloorSurface"
+            ]
+          },
+          "description": "The CityObject or Semantic type where the attribute is located."
         }
       }
     },
     "format-gpkg": {
       "type": "object",
       "properties": {
-        "location": {
-          "type": "string",
-          "enum": [
-            "pand",
-            "lod12_2d",
-            "lod12_3d",
-            "lod13_2d",
-            "lod13_3d",
-            "lod22_2d",
-            "lod22_3d"
-          ],
+        "locations": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "pand",
+              "lod12_2d",
+              "lod12_3d",
+              "lod13_2d",
+              "lod13_3d",
+              "lod22_2d",
+              "lod22_3d"
+            ]
+          },
           "description": "The GeoPackage layer where the attribute is located."
         }
       }

--- a/resources/attributes.schema.json
+++ b/resources/attributes.schema.json
@@ -51,20 +51,16 @@
           "description": "Whether null values are valid for this attribute or they indicate an error in the process."
         },
         "appliesTo": {
-          "type": "string",
-          "enum": [
-            "Building",
-            "RoofSurface",
-            "WallSurface",
-            "GroundSurface",
-            "ClosureSurface",
-            "OuterCeilingSurface",
-            "OuterFloorSurface",
-            "InteriorWallSurface",
-            "CeilingSurface",
-            "FloorSurface"
-          ],
-          "description": "Level where this attribute applies."
+          "properties": {
+            "cityjson": {
+              "$ref": "#/definitions/format-cityjson"
+            },
+            "gpkg": {
+              "$ref": "#/definitions/format-gpkg"
+            }
+          },
+          "minProperties": 1,
+          "additionalProperties": false
         },
         "precision": {
           "type": [
@@ -84,7 +80,7 @@
           ],
           "description": "Unit of measurement."
         },
-        "format": {
+        "valueFormat": {
           "type": [
             "string",
             "null"
@@ -167,6 +163,46 @@
         },
         "scale": {
           "$ref": "#/definitions/translation"
+        }
+      }
+    },
+    "format-cityjson": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string",
+          "enum": [
+            "Building",
+            "BuildingPart",
+            "RoofSurface",
+            "WallSurface",
+            "GroundSurface",
+            "ClosureSurface",
+            "OuterCeilingSurface",
+            "OuterFloorSurface",
+            "InteriorWallSurface",
+            "CeilingSurface",
+            "FloorSurface"
+          ],
+          "description": "The CitObject or Semantic type where the attribute is located."
+        }
+      }
+    },
+    "format-gpkg": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string",
+          "enum": [
+            "pand",
+            "lod12_2d",
+            "lod12_3d",
+            "lod13_2d",
+            "lod13_3d",
+            "lod22_2d",
+            "lod22_3d"
+          ],
+          "description": "The GeoPackage layer where the attribute is located."
         }
       }
     }

--- a/tests/python/test_specs.py
+++ b/tests/python/test_specs.py
@@ -1,5 +1,11 @@
 from bag3d.specs.resources import get_resource_file_path
-from bag3d.specs.core import Attribute, AttributeType, load_attributes_spec, BaseType
+from bag3d.specs.core import (
+    Attribute,
+    AttributeType,
+    load_attributes_spec,
+    BaseType,
+    CityJSONLocation,
+)
 
 
 def test_get_resource_file_path():
@@ -13,10 +19,10 @@ def test_attribute_scalar():
         "type": "string",
         "source": "source",
         "nullable": "true",
-        "appliesTo": "Building",
+        "appliesTo": {},
         "precision": 2,
         "unit": {"en": "metre", "nl": "meter"},
-        "format": "YYYY",
+        "valueFormat": "YYYY",
         "semanticType": "category",
         "values": {"yes": {"nl": "Ja", "en": "Yes"}, "no": {"nl": "Nee", "en": "No"}},
         "description": {"nl": "Test", "en": "Test"},
@@ -36,11 +42,14 @@ def test_attribute_array():
     data = {
         "type": "array",
         "source": "source",
-        "nullable": "true",
-        "appliesTo": "Building",
+        "nullable": True,
+        "appliesTo": {
+            "cityjson": {"locations": ["RoofSurface"]},
+            "gpkg": {"locations": ["lod22_2d"]},
+        },
         "precision": 2,
         "unit": {"en": "metre", "nl": "meter"},
-        "format": "YYYY",
+        "valueFormat": "YYYY",
         "semanticType": "category",
         "values": {"yes": {"nl": "Ja", "en": "Yes"}, "no": {"nl": "Nee", "en": "No"}},
         "description": {"nl": "Test", "en": "Test"},
@@ -58,6 +67,7 @@ def test_attribute_array():
     assert attr.type == AttributeType(BaseType.ARRAY, BaseType.INT)
     assert str(attr.type) == "ARRAY<INT>"
     assert attr.items.scale.en == "ratio"
+    assert CityJSONLocation.RoofSurface in attr.applies_to.cityjson["locations"]
 
 
 def test_load_from_package():


### PR DESCRIPTION
Change `appliesTo` from a single string to data format descriptions, so that we can unambiguously define that an attribute applies to a certain format and a certain location in that format.
For example, the cityobject type `Building` and the layer `pand` are both locations in the CityJSON and the GeoPackage formats. This schema is flexible enough to accommodate future formats and their peculiarities, as we can add format-specific properties besides the `locations`. 
For example:

```json
    "appliesTo": {
      "cityjson": {
        "locations": [
          "RoofSurface"
        ]
      },
      "gpkg": {
        "locations": [
          "lod12_2d",
          "lod13_2d",
          "lod22_2d"
        ]
      }
    },
```

Rename `format` to `valueFormat` to make the meaning more explicit.
